### PR TITLE
Option for allow only one message inside growl container

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,15 @@ app.config(['growlProvider', function(growlProvider) {
 }]);
 ````
 
-###Only one message [default: false]
+###Limit messages count [default: undefined]
 
-Accept only one message inside growl container. Automatically flush collection on each new message. (Message overriding) . Useful
+Accept only one X messages inside growl container. Automatically flush collection to limited count on each new message. (Message overriding) . Useful
 when growl is handling messages corresponding to specified element (for example input box inside form) , and you need to show
-message only for last request , very handy for input validation.
+specified number of messages (for example 1 ) , very handy for input validation.
 
 ````html
 <body>
-    <div growl only-one-message="true"></div>
+    <div growl limit-messages="1"></div>
 </body>
 ````
 

--- a/src/growlDirective.js
+++ b/src/growlDirective.js
@@ -9,7 +9,7 @@ angular.module("angular-growl").directive("growl", ["$rootScope", "$sce",
       scope: {
         reference: '@',
         inline: '@',
-        onlyOneMessage : '='
+        limitMessages : '='
       },
       controller: ['$scope', '$timeout', 'growl',
         function($scope, $timeout, growl) {
@@ -23,12 +23,14 @@ angular.module("angular-growl").directive("growl", ["$rootScope", "$sce",
               message.text = $sce.trustAsHtml(String(message.text));
 
 
-              if($scope.onlyOneMessage === true )
+              if(angular.isDefined($scope.limitMessages))
               {
-                  //clear collection on new message
-                  $scope.messages = [];
+                  var diff = $scope.messages.length - ($scope.limitMessages-1);
+                  if(diff > 0)
+                  {
+                      $scope.messages.splice($scope.limitMessages-1,diff)
+                  }
               }
-
               /** abillity to reverse order (newest first ) **/
               if(growl.reverseOrder())
               {


### PR DESCRIPTION
When you need validation for one input (async validation for input box inside form) it is very handy to have only one (last response from server) message inside container.
