### PR TITLE
Angular 1.3 compatibility fix - demo and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ business logic on the server is able to send messages/notifications to the clien
 var app = angular.module('myApp', ['angular-growl']);
 
 app.config(['growlProvider', '$httpProvider', function(growlProvider, $httpProvider) {
-  $httpProvider.responseInterceptors.push(growlProvider.serverMessagesInterceptor);
+  $httpProvider.interceptors.push(growlProvider.serverMessagesInterceptor);
 }]);
 ````
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -8,7 +8,7 @@ app.config(["growlProvider", "$httpProvider", function(growlProvider, $httpProvi
   growlProvider.messageTextKey("messagetext");
   growlProvider.messageSeverityKey("severity-level");
   growlProvider.onlyUniqueMessages(true);
-  $httpProvider.responseInterceptors.push(growlProvider.serverMessagesInterceptor);
+  $httpProvider.interceptors.push(growlProvider.serverMessagesInterceptor);
 }]);
 
 app.run(function($httpBackend) {


### PR DESCRIPTION
This completes #20 and fixes #28. The README and demo page have contained deprecated usage of the interceptor. That usage is causing apps to fail after Angular 1.3.x fix was introduced (#20). This fix corrects it that growl interceptor works both in AngularJS 1.2.x and 1.3.x.
