### PR TITLE
make the module requireable by node or browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "https://github.com/JanStevens/angular-growl-2"
   },
+  "main": "./build/angular-growl.min.js",
   "author": {
     "name": "Jan Stevens"
   },


### PR DESCRIPTION
Hey @JanStevens !

Thanks for keeping this module up-to-date :) I am using browserify and wanted to use this module, it missed the `main` field in `package.json`.

Do you think you can merge this? Even better if you can make a minor release ^^.

Cheers!
