### PR TITLE
Fix for if inline is set to false on the directive

### DIFF
--- a/src/growlDirective.js
+++ b/src/growlDirective.js
@@ -8,7 +8,7 @@ angular.module("angular-growl").directive("growl", [
       replace: false,
       scope: {
         reference: '@',
-        inline: '@',
+        inline: '=',
         limitMessages : '='
       },
       controller: ['$scope', '$timeout', 'growl', 'growlMessages',
@@ -17,7 +17,7 @@ angular.module("angular-growl").directive("growl", [
 
           growlMessages.initDirective($scope.referenceId, $scope.limitMessages);
           $scope.growlMessages = growlMessages;
-          $scope.inlineMessage = $scope.inline || growl.inlineMessages();
+          $scope.inlineMessage = angular.isDefined($scope.inline) ? $scope.inline : growl.inlineMessages();
 
           $scope.$watch('limitMessages', function(limitMessages) {
             var directive = growlMessages.directives[$scope.referenceId];


### PR DESCRIPTION
If you set the global inline config to true like so:
growlProvider.globalInlineMessages(true);

Then try to create a directive with inline="false", the current code doesn't detect that the inline attribute is set to false. This commit fixes it.
