### PR TITLE
Fix empty title and text

### DIFF
--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -188,8 +188,8 @@ angular.module("angular-growl").provider("growl", function () {
 
     function broadcastMessage (message) {
       if (translate && message.translateMessage) {
-        message.text = translate(message.text, message.variables);
-        message.title = translate(message.title);
+        message.text = translate(message.text, message.variables) || message.text;
+        message.title = translate(message.title) || message.title;
       } else {
         var polation = $interpolate(message.text);
         message.text = polation(message.variables);


### PR DESCRIPTION
Angular-translate returns empty string when translation not found:

    > translate('test',{})
    > ""

It's easy to fix:

    > translate('test',{}) || 'test'
    > "test"