### PR TITLE
added angular as dependencie

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "name": "Jan Stevens"
   },
   "license": "MIT",
+  "dependencies": {
+    "angular": ">=1.2.1"
+  },
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-bump": "0.0.2",


### PR DESCRIPTION
To use npm instead of bower we need angular in the dependencies to use something similar to npms `main-bower-files` module (e.g. a new module named `main-npm-files`).