### PR TITLE
Change growl default style classes (Issue #101)

### DIFF
--- a/src/growlDirective.js
+++ b/src/growlDirective.js
@@ -10,11 +10,8 @@ angular.module("angular-growl").directive("growl", [
         reference: '@',
         inline: '=',
         limitMessages: '=',
-        successClass: '@',
-        infoClass: '@',
-        warningClass: '@',
-        errorClass: '@',
-        dangerClass: '@'
+        styles: '=', // custom css styles defined as json for each severity name {success: 'alert-thumbs-up'}
+        icons: '=' // custom icon styles defined as json for each severity name {success: 'icon-thumbs-up'}
       },
       controller: ['$scope', '$interval', 'growl', 'growlMessages',
         function ($scope, $interval, growl, growlMessages) {
@@ -47,23 +44,15 @@ angular.module("angular-growl").directive("growl", [
           
           $scope.alertClasses = function (message) {
             var _alertClasses = {};
-            
-            var _successClass = $scope.successClass === undefined ? growl.styleClasses().success : $scope.successClass;
-            var _infoClass = $scope.infoClass === undefined ? growl.styleClasses().info : $scope.infoClass;
-            var _warningClass = $scope.warningClass === undefined ? growl.styleClasses().warning : $scope.warningClass;
-            var _errorClass = $scope.errorClass === undefined ? growl.styleClasses().error : $scope.errorClass;
-            var _dangerClass = $scope.dangerClass === undefined ? growl.styleClasses().danger : $scope.dangerClass;
-            
+
             var _alertClasses = {
-              'icon': message.disableIcons === false,
               'alert-dismissable': !message.disableCloseButton
             };
-            
-            _alertClasses[_successClass] = message.severity === "success";
-            _alertClasses[_errorClass] = message.severity === "error"; //bootstrap 2.3
-            _alertClasses[_dangerClass] = message.severity === "error"; //bootstrap 3
-            _alertClasses[_infoClass] = message.severity === "info";
-            _alertClasses[_warningClass] = message.severity === "warning"; //bootstrap 3, no effect in bs 2.3
+
+            for (var _severity in message.severityNames()) {
+              var _styleClasses = $scope.styles === undefined || $scope.styles[_severity] === undefined ? message.styleClasses()[_severity] : $scope.styles[_severity];
+              _alertClasses[_styleClasses] = message.severity === _severity;
+            }
             
             return _alertClasses;
           };
@@ -102,8 +91,9 @@ angular.module("angular-growl").run(['$templateCache', function ($templateCache)
       '<div class="growl-item alert" ng-repeat="message in growlMessages.directives[referenceId].messages" ng-class="alertClasses(message)" ng-click="stopTimeoutClose(message)">' +
       '<button type="button" class="close" data-dismiss="alert" aria-hidden="true" ng-click="growlMessages.deleteMessage(message)" ng-if="!message.disableCloseButton">&times;</button>' +
       '<button type="button" class="close" aria-hidden="true" ng-if="showCountDown(message)">{{message.countdown}}</button>' +
+      '<span ng-class="iconClasses(message)" aria-hidden="true"></span>' +
       '<h4 class="growl-title" ng-if="message.title" ng-bind="message.title"></h4>' +
-      '<div class="growl-message" ng-bind-html="message.text"></div>' +
+      '<span class="growl-message" ng-bind-html="message.text"></span>' +
       '</div>' +
       '</div>'
     );

--- a/src/growlDirective.js
+++ b/src/growlDirective.js
@@ -44,21 +44,15 @@ angular.module("angular-growl").directive("growl", [
               }
             }
           };
-
-          var defaultClasses = {
-            success: 'alert-success',
-            info: 'alert-info',
-            warning: 'alert-warning',
-            error: 'alert-error',
-            danger: 'alert-danger'
-          };
           
           $scope.alertClasses = function (message) {
-            var _successClass = $scope.successClass || defaultClasses.success;
-            var _infoClass = $scope.infoClass || defaultClasses.info;
-            var _warningClass = $scope.warningClass || defaultClasses.warning;
-            var _errorClass = $scope.errorClass || defaultClasses.error;
-            var _dangerClass = $scope.dangerClass || defaultClasses.danger;
+            var _alertClasses = {};
+            
+            var _successClass = $scope.successClass === undefined ? growl.styleClasses().success : $scope.successClass;
+            var _infoClass = $scope.infoClass === undefined ? growl.styleClasses().info : $scope.infoClass;
+            var _warningClass = $scope.warningClass === undefined ? growl.styleClasses().warning : $scope.warningClass;
+            var _errorClass = $scope.errorClass === undefined ? growl.styleClasses().error : $scope.errorClass;
+            var _dangerClass = $scope.dangerClass === undefined ? growl.styleClasses().danger : $scope.dangerClass;
             
             var _alertClasses = {
               'icon': message.disableIcons === false,

--- a/src/growlDirective.js
+++ b/src/growlDirective.js
@@ -9,7 +9,12 @@ angular.module("angular-growl").directive("growl", [
       scope: {
         reference: '@',
         inline: '=',
-        limitMessages: '='
+        limitMessages: '=',
+        successClass: '@',
+        infoClass: '@',
+        warningClass: '@',
+        errorClass: '@',
+        dangerClass: '@'
       },
       controller: ['$scope', '$interval', 'growl', 'growlMessages',
         function ($scope, $interval, growl, growlMessages) {
@@ -40,16 +45,33 @@ angular.module("angular-growl").directive("growl", [
             }
           };
 
+          var defaultClasses = {
+            success: 'alert-success',
+            info: 'alert-info',
+            warning: 'alert-warning',
+            error: 'alert-error',
+            danger: 'alert-danger'
+          };
+          
           $scope.alertClasses = function (message) {
-            return {
-              'alert-success': message.severity === "success",
-              'alert-error': message.severity === "error", //bootstrap 2.3
-              'alert-danger': message.severity === "error", //bootstrap 3
-              'alert-info': message.severity === "info",
-              'alert-warning': message.severity === "warning", //bootstrap 3, no effect in bs 2.3
+            var _successClass = $scope.successClass || defaultClasses.success;
+            var _infoClass = $scope.infoClass || defaultClasses.info;
+            var _warningClass = $scope.warningClass || defaultClasses.warning;
+            var _errorClass = $scope.errorClass || defaultClasses.error;
+            var _dangerClass = $scope.dangerClass || defaultClasses.danger;
+            
+            var _alertClasses = {
               'icon': message.disableIcons === false,
               'alert-dismissable': !message.disableCloseButton
             };
+            
+            _alertClasses[_successClass] = message.severity === "success";
+            _alertClasses[_errorClass] = message.severity === "error"; //bootstrap 2.3
+            _alertClasses[_dangerClass] = message.severity === "error"; //bootstrap 3
+            _alertClasses[_infoClass] = message.severity === "info";
+            _alertClasses[_warningClass] = message.severity === "warning"; //bootstrap 3, no effect in bs 2.3
+            
+            return _alertClasses;
           };
 
           $scope.showCountDown = function (message) {

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -18,6 +18,7 @@ angular.module("angular-growl").provider("growl", function () {
     _reverseOrder = false,
     _disableCountDown = false,
     _translateMessages = true,
+    _defaultSeverity = "error",
     _severityNames = ["success", "info", "warning", "error"],
     _iconClasses = {"success": "icon alert-success", "info": "icon alert-info", "warning": "icon alert-warning",
                      "error": "icon alert-error"},
@@ -127,6 +128,16 @@ angular.module("angular-growl").provider("growl", function () {
   };
 
   /**
+   * set the default severity name used when message's severity is not defined
+   *
+   * @param  {string} defaultSeverity default: "error"
+   */
+  this.globalDefaultSeverity = function (defaultSeverity) {
+    _defaultSeverity = defaultSeverity;
+    return this;
+  };
+
+  /**
    * set accepted severity names
    *
    * @param  {string[]} severityNames default: ["success", "info", "warning", "error"]
@@ -135,7 +146,7 @@ angular.module("angular-growl").provider("growl", function () {
     _severityNames = severityNames;
     return this;
   };
-  
+
   /**
    * sets the message icon classes to use related to a severity.
    *
@@ -157,7 +168,7 @@ angular.module("angular-growl").provider("growl", function () {
     }
     return this;
   };
-  
+
   /**
    * sets the growl style classes to use related to a severity.
    *
@@ -180,8 +191,6 @@ angular.module("angular-growl").provider("growl", function () {
     return this;
   };
 
-
-  
   /**
    * sets the key in $http response the serverMessagesInterecptor is looking for server-sent messages, value of key
    * needs to be an array of objects
@@ -378,7 +387,7 @@ angular.module("angular-growl").provider("growl", function () {
      * @param {string} severity
      */
     function general (text, config, severity) {
-      severity = (severity || "error").toLowerCase();
+      severity = (severity || _defaultSeverity).toLowerCase();
       return sendMessage(text, config, severity);
     }
 
@@ -397,7 +406,7 @@ angular.module("angular-growl").provider("growl", function () {
         message = messages[i];
 
         if (message[_messageTextKey]) {
-          severity = (message[_messageSeverityKey] || "error").toLowerCase();
+          severity = (message[_messageSeverityKey] || _defaultSeverity).toLowerCase();
           var config = {};
           config.variables = message[_messageVariableKey] || {};
           config.title = message[_messageTitleKey];
@@ -427,6 +436,10 @@ angular.module("angular-growl").provider("growl", function () {
     function position () {
       return _position;
     }
+    
+    function severityNames() {
+      return _severityNames;
+    }
 
     function iconClasses () {
       return _iconClasses;
@@ -447,6 +460,7 @@ angular.module("angular-growl").provider("growl", function () {
       reverseOrder: reverseOrder,
       inlineMessages: inlineMessages,
       position: position,
+      severityNames: severityNames,
       iconClasses: iconClasses,
       styleClasses: styleClasses
     };

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -283,8 +283,8 @@ angular.module("angular-growl").provider("growl", function () {
           success: (_config.styleClasses === undefined || _config.styleClasses.success === undefined) ? _styleClasses.success : _config.styleClasses.success,
           info: (_config.styleClasses === undefined || _config.styleClasses.info === undefined) ? _styleClasses.info : _config.styleClasses.info,
           warning: (_config.styleClasses === undefined || _config.styleClasses.warning === undefined) ? _styleClasses.warning : _config.styleClasses.warning,
-          error: (_config.styleClasses === undefined || _config.styleClasses.success.error === undefined) ? _styleClasses.error : _config.styleClasses.error,
-          danger: (_config.styleClasses === undefined || _config.styleClasses.success.danger === undefined) ? _styleClasses.danger : _config.styleClasses.danger,
+          error: (_config.styleClasses === undefined || _config.styleClasses.error === undefined) ? _styleClasses.error : _config.styleClasses.error,
+          danger: (_config.styleClasses === undefined || _config.styleClasses.danger === undefined) ? _styleClasses.danger : _config.styleClasses.danger,
         },
         destroy: function () {
           growlMessages.deleteMessage(message);

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -18,10 +18,11 @@ angular.module("angular-growl").provider("growl", function () {
     _reverseOrder = false,
     _disableCountDown = false,
     _translateMessages = true,
-    _iconClasses = {success: 'icon alert-success', info: 'icon alert-info', warning: 'icon alert-warning',
-                     error: 'icon alert-error'},
-    _styleClasses = {success: 'alert-success', info: 'alert-info', warning: 'alert-warning',
-                     error: 'alert-error'};
+    _severityNames = ["success", "info", "warning", "error"],
+    _iconClasses = {"success": "icon alert-success", "info": "icon alert-info", "warning": "icon alert-warning",
+                     "error": "icon alert-error"},
+    _styleClasses = {"success": "alert-success", "info": "alert-info", "warning": "alert-warning",
+                     "error": "alert-error"};
 
   /**
    * set a global timeout (time to live) after which messages will be automatically closed
@@ -122,6 +123,16 @@ angular.module("angular-growl").provider("growl", function () {
    */
   this.globalPosition = function (position) {
     _position = position;
+    return this;
+  };
+
+  /**
+   * set accepted severity names
+   *
+   * @param  {string[]} severityNames default: ["success", "info", "warning", "error"]
+   */
+  this.globalSeverityNames = function (severityNames) {
+    _severityNames = severityNames;
     return this;
   };
   
@@ -298,18 +309,8 @@ angular.module("angular-growl").provider("growl", function () {
         position: _config.position || _position,
         referenceId: _config.referenceId || _referenceId,
         translateMessage: _config.translateMessage === undefined ? _translateMessages : _config.translateMessage,
-        styleClasses: {
-          success: (_config.styleClasses === undefined || _config.styleClasses.success === undefined) ? _styleClasses.success : _config.styleClasses.success,
-          info: (_config.styleClasses === undefined || _config.styleClasses.info === undefined) ? _styleClasses.info : _config.styleClasses.info,
-          warning: (_config.styleClasses === undefined || _config.styleClasses.warning === undefined) ? _styleClasses.warning : _config.styleClasses.warning,
-          error: (_config.styleClasses === undefined || _config.styleClasses.error === undefined) ? _styleClasses.error : _config.styleClasses.error,
-        },
-        iconClasses: {
-          success: (_config.iconClasses === undefined || _config.iconClasses.success === undefined) ? _iconClasses.success : _config.iconClasses.success,
-          info: (_config.iconClasses === undefined || _config.iconClasses.info === undefined) ? _iconClasses.info : _config.iconClasses.info,
-          warning: (_config.iconClasses === undefined || _config.iconClasses.warning === undefined) ? _iconClasses.warning : _config.iconClasses.warning,
-          error: (_config.iconClasses === undefined || _config.iconClasses.error === undefined) ? _iconClasses.error : _config.iconClasses.error,
-        },
+        styleClasses: (_config.styleClasses === undefined || _config.styleClasses[severity] === undefined) ? _styleClasses.success : _config.styleClasses[severity],
+        iconClasses: (_config.iconClasses === undefined || _config.iconClasses[severity] === undefined) ? _iconClasses.success : _config.iconClasses[severity],
         destroy: function () {
           growlMessages.deleteMessage(message);
         },

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -18,8 +18,10 @@ angular.module("angular-growl").provider("growl", function () {
     _reverseOrder = false,
     _disableCountDown = false,
     _translateMessages = true,
+    _iconClasses = {success: 'icon alert-success', info: 'icon alert-info', warning: 'icon alert-warning',
+                     error: 'icon alert-error'},
     _styleClasses = {success: 'alert-success', info: 'alert-info', warning: 'alert-warning',
-                     error: 'alert-error', danger: 'alert-danger'};
+                     error: 'alert-error'};
 
   /**
    * set a global timeout (time to live) after which messages will be automatically closed
@@ -124,13 +126,30 @@ angular.module("angular-growl").provider("growl", function () {
   };
   
   /**
-   * sets the style classes to use related to a severity.
-   * 'danger' and 'error' are related to error severity, but have distinct styles
-   * 
+   * sets the message icon classes to use related to a severity.
+   *
+   * @param {object} iconClasses default: 
+   *     {success: 'icon alert-success', info: 'icon alert-info', warning: 'icon alert-warning',
+   *      error: 'icon alert-error'}
+   */
+  this.globalIconClasses = function (iconClasses) {
+    if (iconClasses) {
+      // only change the styles defined by the user
+      // if not added to customized object then don't change default one
+      _iconClasses.success = iconClasses.success || _iconClasses.success;
+      _iconClasses.info = iconClasses.info || _iconClasses.info;
+      _iconClasses.warning = iconClasses.warning || _iconClasses.warning;
+      _iconClasses.error = iconClasses.error || _iconClasses.error;
+    }
+    return this;
+  };
+  
+  /**
+   * sets the growl style classes to use related to a severity.
    *
    * @param {object} styleClasses default: 
    *     {success: 'alert-success', info: 'alert-info', warning: 'alert-warning',
-   *      error: 'alert-error', danger: 'alert-danger'}
+   *      error: 'alert-error'}
    */
   this.globalStyleClasses = function (styleClasses) {
     if (styleClasses) {
@@ -140,10 +159,10 @@ angular.module("angular-growl").provider("growl", function () {
       _styleClasses.info = styleClasses.info || _styleClasses.info;
       _styleClasses.warning = styleClasses.warning || _styleClasses.warning;
       _styleClasses.error = styleClasses.error || _styleClasses.error;
-      _styleClasses.danger = styleClasses.danger || _styleClasses.danger;
     }
     return this;
   };
+
 
   
   /**
@@ -284,7 +303,12 @@ angular.module("angular-growl").provider("growl", function () {
           info: (_config.styleClasses === undefined || _config.styleClasses.info === undefined) ? _styleClasses.info : _config.styleClasses.info,
           warning: (_config.styleClasses === undefined || _config.styleClasses.warning === undefined) ? _styleClasses.warning : _config.styleClasses.warning,
           error: (_config.styleClasses === undefined || _config.styleClasses.error === undefined) ? _styleClasses.error : _config.styleClasses.error,
-          danger: (_config.styleClasses === undefined || _config.styleClasses.danger === undefined) ? _styleClasses.danger : _config.styleClasses.danger,
+        },
+        iconClasses: {
+          success: (_config.iconClasses === undefined || _config.iconClasses.success === undefined) ? _iconClasses.success : _config.iconClasses.success,
+          info: (_config.iconClasses === undefined || _config.iconClasses.info === undefined) ? _iconClasses.info : _config.iconClasses.info,
+          warning: (_config.iconClasses === undefined || _config.iconClasses.warning === undefined) ? _iconClasses.warning : _config.iconClasses.warning,
+          error: (_config.iconClasses === undefined || _config.iconClasses.error === undefined) ? _iconClasses.error : _config.iconClasses.error,
         },
         destroy: function () {
           growlMessages.deleteMessage(message);
@@ -396,7 +420,11 @@ angular.module("angular-growl").provider("growl", function () {
     function position () {
       return _position;
     }
-    
+
+    function iconClasses () {
+      return _iconClasses;
+    }
+
     function styleClasses () {
       return _styleClasses;
     }
@@ -412,6 +440,7 @@ angular.module("angular-growl").provider("growl", function () {
       reverseOrder: reverseOrder,
       inlineMessages: inlineMessages,
       position: position,
+      iconClasses: iconClasses,
       styleClasses: styleClasses
     };
   }];

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -279,6 +279,13 @@ angular.module("angular-growl").provider("growl", function () {
         position: _config.position || _position,
         referenceId: _config.referenceId || _referenceId,
         translateMessage: _config.translateMessage === undefined ? _translateMessages : _config.translateMessage,
+        styleClasses: {
+          success: (_config.styleClasses === undefined || _config.styleClasses.success === undefined) ? _styleClasses.success : _config.styleClasses.success,
+          info: (_config.styleClasses === undefined || _config.styleClasses.info === undefined) ? _styleClasses.info : _config.styleClasses.info,
+          warning: (_config.styleClasses === undefined || _config.styleClasses.warning === undefined) ? _styleClasses.warning : _config.styleClasses.warning,
+          error: (_config.styleClasses === undefined || _config.styleClasses.success.error === undefined) ? _styleClasses.error : _config.styleClasses.error,
+          danger: (_config.styleClasses === undefined || _config.styleClasses.success.danger === undefined) ? _styleClasses.danger : _config.styleClasses.danger,
+        },
         destroy: function () {
           growlMessages.deleteMessage(message);
         },
@@ -389,6 +396,10 @@ angular.module("angular-growl").provider("growl", function () {
     function position () {
       return _position;
     }
+    
+    function styleClasses () {
+      return _styleClasses;
+    }
 
     return {
       warning: warning,
@@ -400,7 +411,8 @@ angular.module("angular-growl").provider("growl", function () {
       onlyUnique: onlyUnique,
       reverseOrder: reverseOrder,
       inlineMessages: inlineMessages,
-      position: position
+      position: position,
+      styleClasses: styleClasses
     };
   }];
 });

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -17,7 +17,9 @@ angular.module("angular-growl").provider("growl", function () {
     _disableIcons = false,
     _reverseOrder = false,
     _disableCountDown = false,
-    _translateMessages = true;
+    _translateMessages = true,
+    _styleClasses = {success: 'alert-success', info: 'alert-info', warning: 'alert-warning',
+                     error: 'alert-error', danger: 'alert-danger'};
 
   /**
    * set a global timeout (time to live) after which messages will be automatically closed
@@ -120,6 +122,30 @@ angular.module("angular-growl").provider("growl", function () {
     _position = position;
     return this;
   };
+  
+  /**
+   * sets the style classes to use related to a severity.
+   * 'danger' and 'error' are related to error severity, but have distinct styles
+   * 
+   *
+   * @param {object} styleClasses default: 
+   *     {success: 'alert-success', info: 'alert-info', warning: 'alert-warning',
+   *      error: 'alert-error', danger: 'alert-danger'}
+   */
+  this.globalStyleClasses = function (styleClasses) {
+    if (styleClasses) {
+      // only change the styles defined by the user
+      // if not added to customized object then don't change default one
+      _styleClasses.success = styleClasses.success || _styleClasses.success;
+      _styleClasses.info = styleClasses.info || _styleClasses.info;
+      _styleClasses.warning = styleClasses.warning || _styleClasses.warning;
+      _styleClasses.error = styleClasses.error || _styleClasses.error;
+      _styleClasses.danger = styleClasses.danger || _styleClasses.danger;
+    }
+    return this;
+  };
+
+  
   /**
    * sets the key in $http response the serverMessagesInterecptor is looking for server-sent messages, value of key
    * needs to be an array of objects

--- a/src/growlFactory.js
+++ b/src/growlFactory.js
@@ -147,10 +147,13 @@ angular.module("angular-growl").provider("growl", function () {
     if (iconClasses) {
       // only change the styles defined by the user
       // if not added to customized object then don't change default one
-      _iconClasses.success = iconClasses.success || _iconClasses.success;
-      _iconClasses.info = iconClasses.info || _iconClasses.info;
-      _iconClasses.warning = iconClasses.warning || _iconClasses.warning;
-      _iconClasses.error = iconClasses.error || _iconClasses.error;
+      if (typeof iconClasses === 'object') {
+        for (var k in iconClasses) {
+          if (iconClasses.hasOwnProperty(k)) {
+            _iconClasses[k] = iconClasses[k];
+          }
+        }
+      }
     }
     return this;
   };
@@ -166,10 +169,13 @@ angular.module("angular-growl").provider("growl", function () {
     if (styleClasses) {
       // only change the styles defined by the user
       // if not added to customized object then don't change default one
-      _styleClasses.success = styleClasses.success || _styleClasses.success;
-      _styleClasses.info = styleClasses.info || _styleClasses.info;
-      _styleClasses.warning = styleClasses.warning || _styleClasses.warning;
-      _styleClasses.error = styleClasses.error || _styleClasses.error;
+      if (typeof styleClasses === 'object') {
+        for (var k in styleClasses) {
+          if (styleClasses.hasOwnProperty(k)) {
+            _styleClasses[k] = styleClasses[k];
+          }
+        }
+      }
     }
     return this;
   };


### PR DESCRIPTION
Motivated by the Issue #101, I implemented some basic changes to angular-growl-2 to allow users to define another set of style classes for all growl tags and also for a specific growl.

Global config object should use the format below (samples are using FontAwesome styles just to relate to the issue, but could be used any style class names from any similar icon library):

```
config: {
...
styleClasses: {
    success: 'fa fa-check-circle',
    info: 'fa fa-info-circle',
    warning: 'fa fa-exclamation-circle',
    error: 'fa fa-times-circle',
    danger: 'fa fa-times-circle'}
...
}
```

All styleClasses attributes are optional and if not defined will fallback to the actual default value.
If a user want to suppress an icon an empty string should be passed as the attribute value for the specific severity.

A specific growl tag could use custom style classes adding some attributes to it, like this:

`
<growl ... success-class="fa fa-check" info-class="fa fa-info" warning-class="fa fa-exclamation" error-class="fa fa-times" danger-class="fa fa-times">...</growl>
`

I'll provide a [Plunker](https://plnkr.co) with samples for these situations.

Hope it will help.